### PR TITLE
Freeze PaperMC v1.20.1

### DIFF
--- a/scripts/templates/settings.env.jinja2
+++ b/scripts/templates/settings.env.jinja2
@@ -1,11 +1,13 @@
 UID = "{{ UID }}"
 GID = "{{ GID }}"
 TYPE = "PAPER"
+VERSION = "1.20.1"
 EULA = "true"
 SERVER_NAME = "{{ SERVER_NAME }}"
 SEED = "{{ SEED }}"
 MODE = "{{ MODE }}"
 RCON = "true"
 RCON_PASSWORD = "{{ RCON_PASSWORD }}"
-MODRINTH_PROJECTS = "coreprotect,dynmap,essentialsx"
+MODRINTH_PROJECTS = "coreprotect,dynmap:beta,essentialsx"
+#DEBUG_HELPER = true
 


### PR DESCRIPTION
Freeze PaperMC version to 1.20.1

Why?: when initially setting this up, minecraft v1.20 was released which, in the short term, and understandably, broke all plugins.
This is one step toward stopping that in future.