### PR TITLE
Dynmap HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 # Folders
-backups
-data
+/backups
+/data
 
 # Genreated files
-settings.env
-tasks.cron
+/settings.env
+/tasks.cron
+/init-letsencrypt.sh
+/nginx.conf
 
 # Logs
 *.log

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ This will ask you a few questions, but will randomise everything if you don't pr
 
 Note: randomising a password may be a good idea, since it will be harder to guess.
 
+Also note: if you don't intend on using `https` for dynmap, you can ignore the questions for `init-letsencrypt.sh` and `nginx.conf`.
+Or, if you do, but want to set it up later, you can always re-run `init`.
+
 ### Start Server
 
 ```bash
@@ -119,9 +122,38 @@ Press `[Ctrl]+[D]` to exit the RCON-CLI. This is likely the only time you'll nee
 
 The [dynmap](https://github.com/webbukkit/dynmap) plugin provides a live view of the world, and players in it.
 
-You can then view it on port `8123`: http://localhost:8123
+Once minecraft is running, you can view it on port `8123`: http://localhost:8123
 
 <img src="doc/img/dynmap-01-world-flat.png" width=45% />
+
+### Public HTTPS
+
+To access `dynmap` remotely, it's highly recommended you enable login support by setting the following `true` in `data/plugins/dynmap/configuration.txt`
+
+```yaml
+# Enable login support
+login-enabled: true
+# Require login to access website (requires login-enabled: true)
+login-required: true
+```
+
+And using the reverse-proxy configured in the `nginx` docker-compose service.
+
+Pre-requisites:
+
+- You have control over the host running on the domain
+- The host has ports 443, and 80 exposed (80 required for initial certification... it's a long story)
+
+If you don't own a small part of the internet (eg: an AWS EC2 instance, and root domain), don't worry. You can achieve this with a dynamic DNS (I use [`duckdns.org`](https://www.duckdns.org)), allowing you to "own" (for free) a domain like `made-up-name.duckdns.org` which can point to your house, even if your ISP doesn't provide you a static IP 👍.
+
+Once you're ready, initialise with:
+
+```bash
+bash init-letsencrypt.sh
+```
+
+If all of this confuses you, that's normal 😵‍💫.\
+To learn how this works, search for "reverse proxy with nginx and docker". I've used [`wmnnd/nginx-certbot`](https://github.com/wmnnd/nginx-certbot) as a boilerplate for this & other projects (it's brilliant).
 
 ## Backup
 
@@ -134,6 +166,7 @@ Backing up couldn't be simpler than:
 The first time it's run, it will create a duplicate of the `./data` folder.
 
 Each subsequent time it's run, it will only copy new, and changed files. Any files that have not chnaged since last backed up will be [hard linked](https://en.wikipedia.org/wiki/Hard_link) to the previous backup.
+
 
 ### Restoring a backup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ services:
       # shared with certbot (for https certs)
       - ./data/certbot/conf:/etc/letsencrypt
       - certbot_www:/var/www/certbot
-    depends_on:
-      - django
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     profiles: ["reverse-proxy"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-version: "3.8"
+version: "3.9"
 
 services:
   ds-java:
     image: itzg/minecraft-server
+    restart: unless-stopped
     env_file:
       - ./settings.env
     ports:
@@ -13,4 +14,33 @@ services:
       - ./data:/data
     stdin_open: true
     tty: true
+
+  # Reverse Proxy
+  nginx:
+    image: nginx:1.20-alpine
     restart: unless-stopped
+    ports:
+      - 443:443
+      - 80:80
+    volumes:
+      # nginx config
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      # shared with certbot (for https certs)
+      - ./data/certbot/conf:/etc/letsencrypt
+      - certbot_www:/var/www/certbot
+    depends_on:
+      - django
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+    profiles: ["reverse-proxy"]
+
+  certbot:
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - ./data/certbot/conf:/etc/letsencrypt/
+      - certbot_www:/var/www/certbot/
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    profiles: ["reverse-proxy"]
+
+volumes:
+  certbot_www:

--- a/scripts/templates/init-letsencrypt.sh.jinja2
+++ b/scripts/templates/init-letsencrypt.sh.jinja2
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# source: https://github.com/wmnnd/nginx-certbot
+set -e
+cd $(dirname $0)
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
+domains=({{ SSL_DOMAIN }})
+rsa_key_size=4096
+data_path="./data/certbot"
+email="{{ SSL_EMAIL }}"
+staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload

--- a/scripts/templates/nginx.conf.jinja2
+++ b/scripts/templates/nginx.conf.jinja2
@@ -1,0 +1,43 @@
+upstream minecraft_dynmap {
+    server ds-java:8123;
+}
+
+server {
+    listen 80;
+    server_name {{ SSL_DOMAIN }};
+    server_tokens off;
+
+    # Certbot via port 80 : reading
+    #   ref: https://community.letsencrypt.org/t/renewal-acme-challenge-over-https/79482
+    #   ref: https://letsencrypt.org/docs/allow-port-80/
+
+    # Accessed to auth the first SSL certificate (for HTTPS):
+    #   - when first setting up server
+    #   - if certificate expired & needs refreshing
+    location /.well-known/acme-challenge/ { root /var/www/certbot; }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name {{ SSL_DOMAIN }};
+    server_tokens off;
+
+    ssl_certificate /etc/letsencrypt/live/{{ SSL_DOMAIN }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ SSL_DOMAIN }}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Accessed to auth updating SSL certificate (for HTTPS)
+    location /.well-known/acme-challenge/ { root /var/www/certbot; }
+
+    location / {
+        proxy_pass http://minecraft_dynmap;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+}


### PR DESCRIPTION
The Dynmap plugin publishes an webpage on port 8123 via HTTP (ie: not secure).
This update allows a user to call upon the letsencrypt gods to issue a certificate on their server.
It's currently limited to port 443... but it's better than nothing.