### PR TITLE
Bugfix: Notify logs abandoned

### DIFF
--- a/notify/keys.env.template
+++ b/notify/keys.env.template
@@ -8,3 +8,6 @@ PUSHOVER_USER_KEY =
 
 # Slack - https://api.slack.com/apps
 SLACK_WEBHOOK_URL = 
+
+# Debug - (uncomment to show verbose logs)
+#NOTIFY_DEBUG=1

--- a/notify/lib/logs.py
+++ b/notify/lib/logs.py
@@ -110,7 +110,7 @@ class LogMessage:
                     if not (line := logfile.readline()):
                         while (event := next(event_iter)):
                             (_, e_types, _, _) = event
-                            if 'IN_DELETE' in e_types:
+                            if any(x in e_types for x in ('IN_DELETE', 'IN_MOVED_FROM')):
                                 file_exists = False
                                 break
                         time.sleep(cls.RETRY_PERIOD)

--- a/notify/lib/logs.py
+++ b/notify/lib/logs.py
@@ -5,6 +5,9 @@ import time
 import re
 import os
 import datetime
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def inotify_event_gen(filename):
@@ -22,6 +25,7 @@ def inotify_event_gen(filename):
             continue
         (_, _, e_path, e_filename) = event
         if (e_path, e_filename) == (path, fname):
+            log.debug("inotify event: %r", event)
             yield event
 
 
@@ -71,7 +75,7 @@ class LogMessage:
         return f"[{self.datetime.isoformat()}] [{self.owner}] {self.message}"
 
     @classmethod
-    def from_file_gen(cls, filename, verbose=False):
+    def from_file_gen(cls, filename):
         event_iter = inotify_event_gen(filename)  # 'IN_DELETE'
         date = None  # will be set per file from file_gen()
 
@@ -79,6 +83,7 @@ class LogMessage:
             first = True
             while True:
                 # wait for file to exist
+                log.debug("looking for file: %r", filename)
                 while not os.path.exists(filename):
                     first = False  # if it doesn't initially exist, we'll want to see all content once it does
                     time.sleep(cls.RETRY_PERIOD)
@@ -91,9 +96,9 @@ class LogMessage:
                 offset = os.path.getsize(filename) if first else 0
                 first = False
 
+                log.info("opening logfile: %r", filename)
+                log.debug("date=%r, offset=%r", date, offset)
                 with open(filename, 'r') as handle:
-                    if verbose:
-                        print(f'logfile opened: {filename!r}')
                     if offset:
                         handle.seek(offset)
                     yield handle
@@ -110,6 +115,7 @@ class LogMessage:
                                 break
                         time.sleep(cls.RETRY_PERIOD)
                         continue
+                    log.debug("log entry: %r", line)
                     yield line.rstrip()
         
         for line in line_gen():

--- a/notify/service.py
+++ b/notify/service.py
@@ -6,8 +6,12 @@ sys.path.insert(0, os.path.normpath(os.path.join(_this_dir, 'lib')))
 
 import webhooks
 import logs
+import logging
+
+log = logging.getLogger(__name__)
 
 DEFAULT_LOGFILE = os.path.normpath(os.path.join(_this_dir, '..', 'data', 'logs', 'latest.log'))
+AFFIRMATIVE = {'1', 'yes', 'on', 'true'}  # lower case
 
 
 def main():
@@ -18,15 +22,23 @@ def main():
         '--logfile', default=DEFAULT_LOGFILE, metavar='LOG',
         help="PaperMC logfile (<server data>/logs/latest.log)",
     )
+    parser.add_argument(
+        '--debug', dest='loglevel',
+        action='store_const', const=logging.DEBUG,
+        default=logging.DEBUG if os.environ.get('DEBUG', '').lower() in AFFIRMATIVE else logging.INFO,
+        help="Log all the things",
+    )
     args = parser.parse_args()
+    
+    # --- Logging (outward)
+    logging.basicConfig(level=args.loglevel)
     
     # --- Process Logfile (follow)
     hooks = list(webhooks.default_gen())
-    for msg in logs.LogMessage.from_file_gen(args.logfile, verbose=True):
+    for msg in logs.LogMessage.from_file_gen(args.logfile):
         for hook in hooks:
             if hook.process(msg):
-                print(f"sent webhook: {hook}")
-
+                log.info("sent webhook %r for message: %s", hook, msg)
 
 if __name__ == '__main__':
     main()

--- a/notify/service.py
+++ b/notify/service.py
@@ -25,7 +25,7 @@ def main():
     parser.add_argument(
         '--debug', dest='loglevel',
         action='store_const', const=logging.DEBUG,
-        default=logging.DEBUG if os.environ.get('DEBUG', '').lower() in AFFIRMATIVE else logging.INFO,
+        default=logging.DEBUG if os.environ.get('NOTIFY_DEBUG', '').lower() in AFFIRMATIVE else logging.INFO,
         help="Log all the things",
     )
     args = parser.parse_args()


### PR DESCRIPTION
Notifications work for the 1st day, but stop happening once the logs are rotated (zipped, and a new one created).

This fixes that issue, as `latest.log` is flagged by _inotify_ as `IN_MOVED_FROM` (not `IN_DELETE` as expected)